### PR TITLE
Fix history exception

### DIFF
--- a/extensions/history.scm
+++ b/extensions/history.scm
@@ -73,7 +73,8 @@
 ;;; hook procedure for logging all received messages
 (define (log-received-message time from nickname message)
   "hook procedure for logging all received messages"
-  (history (string-append history-path "/" from)
+  (history (string-append history-path "/"
+                  (regexp-substitute #f (string-match "/.*$" from) 'pre "" 'post))
            from
            message))
 


### PR DESCRIPTION
- Fix history exception when saving a gtalk chat : the history module saves the log in a file named 'foo@gmail/gmail.xxx', remove '/gmail.xxx' from the file path to avoid an exception raise
- Fix typo
