### PR TITLE
current_buddy points to a roster item instead

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -391,10 +391,8 @@ do_send_message (char *jid, char *msg_str)
 int
 do_set_current_buddy (char *bud)
 {
-        if (state.current_buddy)
-                g_free (state.current_buddy);
         if (bud)
-                state.current_buddy = g_strdup (bud);
+                state.current_buddy = ft_roster_lookup (bud);
         else
                 state.current_buddy = NULL;
         return 0;
@@ -403,7 +401,7 @@ do_set_current_buddy (char *bud)
 const char *
 do_get_current_buddy (void)
 {
-        return state.current_buddy ? state.current_buddy : "";
+        return state.current_buddy ? state.current_buddy->jid : "";
 }
 
 static void

--- a/src/freetalk.h
+++ b/src/freetalk.h
@@ -28,6 +28,7 @@
 #include <loudmouth/loudmouth.h>
 #include <time.h>
 #include "util.h"
+#include "roster.h"
 
 #define FT_GLOBAL_EXT_DIR   DATADIR "/" PACKAGE_NAME "/extensions"
 #define FT_LOCAL_EXT_DIR    "." PACKAGE_NAME "/extensions" /* relative to $HOME */
@@ -46,7 +47,7 @@ typedef struct {
         char *jid_str;
         jid_t jid;
         char *password;
-        char *current_buddy; /* autoinsertion */
+        FtRosterItem *current_buddy;
         LmConnection *conn; /* = (LmConnection *) conn */
         char *prompt; /* "freetalk> " */
         GError *error;

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -102,7 +102,7 @@ interpreter (char *line)
                 goto out;
         } else {
             if (state.current_buddy) {
-                do_send_message(g_strdup(state.current_buddy), line);
+                do_send_message(state.current_buddy->jid, line);
                 ret = 0;
                 goto out;
             }


### PR DESCRIPTION
Let current_buddy point to a roster item. We will need that later when the code will try to extract the nickname.
