### PR TITLE
/help argument is no more leaded by a slash

### DIFF
--- a/extensions/broadcast.scm
+++ b/extensions/broadcast.scm
@@ -39,6 +39,6 @@
                               message)
         (ft-display (_ "usage: /broadcast [MESSAGE]")))))
 
-(add-command! /broadcast "/broadcast" "/broadcast [MESSAGE]"
+(add-command! /broadcast "broadcast" "/broadcast [MESSAGE]"
               "Send messages to all buddies")
 (add-command! /broadcast "*" "* [MESSAGE]" "Send messages to all the buddies")

--- a/extensions/color.scm
+++ b/extensions/color.scm
@@ -133,7 +133,7 @@
   (set! enable-colors-flag "yes")
   (ft-display (_ " BUDDY coloring enabled ")))
 
-(add-command! /color-enable "/color-enable" "color-enable"
+(add-command! /color-enable "color-enable" "/color-enable"
               "Enables buddy coloring")
 
 (define (/color-disable args)
@@ -141,5 +141,5 @@
   (set! enable-colors-flag "no")
   (ft-display (_ " BUDDY coloring disabled ")))
 
-(add-command! /color-disable "/color-disable" "color-disable"
+(add-command! /color-disable "color-disable" "/color-disable"
               "Disables buddy coloring")

--- a/extensions/connection.scm
+++ b/extensions/connection.scm
@@ -126,7 +126,7 @@
 
 (define (/connect args)
   (connect-handle (ft-connect)))
-(add-command! /connect "/connect" "/connect"
+(add-command! /connect "connect" "/connect"
               "connect to jabber server - non blocking")
 
 (define (/login args)
@@ -150,19 +150,19 @@
           (read-proxypasswd)
           ""))
     (connect-handle (ft-connect))))
-(add-command! /login "/login" "/login"
+(add-command! /login "login" "/login"
               "Interactive login to jabber server - blocking")
 
 (define (/disconnect args)
   (ft-disconnect))
-(add-command! /disconnect "/disconnect" "/disconnect"
+(add-command! /disconnect "disconnect" "/disconnect"
               "disconnect from jabber server")
-(add-command! /disconnect "/logout" "/logout"
+(add-command! /disconnect "logout" "/logout"
               "logout from jabber server (same as disconnect)")
 
 (define (/change-password args)
   (ft-change-password (sans-surrounding-whitespace args)))
-(add-command! /change-password "/change-password" "/change-password"
+(add-command! /change-password "change-password" "/change-password"
               "change password for current JID")
 
 (define (login-cb success?)

--- a/extensions/dict-buddy.scm
+++ b/extensions/dict-buddy.scm
@@ -25,4 +25,4 @@
         ; (fh-set-current-target-buddy! "dict" "send")
         (system (string-append "dict -P more \"" args "\"")))))
 
-(add-command! /dict "/dict" "/dict [OPTIONS] [WORD]" "lookup in dictionary")
+(add-command! /dict "dict" "/dict [OPTIONS] [WORD]" "lookup in dictionary")

--- a/extensions/dyn-commands.scm
+++ b/extensions/dyn-commands.scm
@@ -42,7 +42,7 @@
      (if cmd-entry
         (begin
           ((car cmd-entry) args)
-          (ft-hook-return)))) (assoc-ref dynamic-command-registry command)))
+          (ft-hook-return)))) (assoc-ref dynamic-command-registry (substring/read-only command 1))))
 (add-hook! ft-command-hook dynamic-command-proc)
 
 (define (help args)
@@ -72,5 +72,4 @@
                         (lambda (a b)
                           (string<? (car a) (car b))))))))
 
-(add-command! help "help" "help [COMMAND]" "show help")
-(add-command! help "/help" "/help [COMMAND]" "show help")
+(add-command! help "help" "/help [COMMAND]" "show help")

--- a/extensions/hacker-romance.scm
+++ b/extensions/hacker-romance.scm
@@ -44,7 +44,7 @@
               (burst-of-romance (string-trim-right buddy #\:) count message)))
         (ft-display (_ "usage: /burst-of-romance BUDDY COUNT MESSAGE")))))
 
-(add-command! /burst-of-romance "/burst-of-romance"
+(add-command! /burst-of-romance "burst-of-romance"
               "/burst-of-romance BUDDY COUNT MESSAGE"
               "send COUNT number of MESSAGEs to BUDDY as though you typed by hand")
 
@@ -78,7 +78,7 @@
                                                               max-chars))
         (ft-display (_ "usage: /burst BUDDY MESSAGE")))))
 
-(add-command! /burst "/burst"
+(add-command! /burst "burst"
               "/burst BUDDY MESSAGE"
               "Send IRC greeting style MESSAGE")
 
@@ -92,6 +92,6 @@
                               min-chars max-chars))
       (ft-display (_ "usage: /greet BUDDY"))))
 
-(add-command! /greet "/greet"
+(add-command! /greet "greet"
               "/greet BUDDY"
               "greet like in IRC")

--- a/extensions/history.scm
+++ b/extensions/history.scm
@@ -126,7 +126,7 @@
                              (string-trim-right (string-trim-right
                                                  args #\space) #\:)))))
 
-(add-command! /history "/history" "/history [BUDDY]"
+(add-command! /history "history" "/history [BUDDY]"
               "Display history page by page")
 
 (define (/history-enable args)
@@ -134,7 +134,7 @@
   (set! enable-history-flag "yes")
   (ft-display (_ " BUDDY history enabled ")))
 
-(add-command! /history-enable "/history-enable" "history-enable"
+(add-command! /history-enable "history-enable" "/history-enable"
               "Enables buddy logging")
 
 (define (/history-disable args)
@@ -142,5 +142,5 @@
   (set! enable-history-flag "no")
   (ft-display (_ " BUDDY history disabled ")))
 
-(add-command! /history-disable "/history-disable" "history-disable"
+(add-command! /history-disable "history-disable" "/history-disable"
               "Disables buddy logging")

--- a/extensions/loudscream.scm
+++ b/extensions/loudscream.scm
@@ -95,4 +95,4 @@
                     )))
       (seed)))
 
-(add-command! safe-repl "/repl" "/repl" "drop into a repl")
+(add-command! safe-repl "repl" "/repl" "drop into a repl")

--- a/extensions/pipe.scm
+++ b/extensions/pipe.scm
@@ -39,6 +39,6 @@
         (send-message-pipe (string-trim-right buddy #\:) cmd)
         (ft-display (_ "usage: /pipe BUDDY COMMAND [OPTIONS]")))))
 
-(add-command! /pipe "/pipe"
+(add-command! /pipe "pipe"
               "/pipe BUDDY COMMAND [OPTIONS]"
               "send the output of COMMAND to BUDDY")

--- a/extensions/proud-of-freetalk.scm
+++ b/extensions/proud-of-freetalk.scm
@@ -68,4 +68,4 @@
       (freetalk? (sans-surrounding-whitespace args))
       (display (_ "proud-of-freetalk.scm: wrong number of arguments to /freetalk\n"))))
 
-(add-command! /freetalk "/freetalk" "/freetalk BUDDY" "check whether a BUDDY is using freetalk")
+(add-command! /freetalk "freetalk" "/freetalk BUDDY" "check whether a BUDDY is using freetalk")

--- a/extensions/roster.scm
+++ b/extensions/roster.scm
@@ -25,7 +25,7 @@
         (ft-subscription-allow (string-trim-right (sans-surrounding-whitespace
                                                    args) #\:)))))
 
-(add-command! /add "/add" "/add [USER@SERVER]" "add new buddy to list")
+(add-command! /add "add" "/add [USER@SERVER]" "add new buddy to list")
 
 (define (/remove args)
   (if (= (string-length args) 0)
@@ -36,7 +36,7 @@
         (ft-subscription-deny (string-trim-right (sans-surrounding-whitespace
                                                   args) #\:)))))
 
-(add-command! /remove "/remove" "/remove [USER@SERVER]"
+(add-command! /remove "remove" "/remove [USER@SERVER]"
               "remove buddy from list")
 
 (define (pretty-print-show-msg msg)
@@ -72,14 +72,14 @@
                                                                                         " ")))))))
             (ft-get-roster-list)))
 
-(add-command! /who "/who" "/who" "display buddy list")
+(add-command! /who "who" "/who" "display buddy list")
 
 (define (/whoami args)
   (ft-display (string-append (_ "Jabber ID: ") (ft-get-jid) "\n"
                              (_ "Jabber Server: ") (ft-get-server) "\n"
                              (_ "Status: ") (ft-get-status-msg))))
 
-(add-command! /whoami "/whoami" "/whoami" "display who is this")
+(add-command! /whoami "whoami" "/whoami" "display who is this")
 
 (define (/allow args)
   (if (= (string-length args) 0)
@@ -87,21 +87,21 @@
       (ft-subscription-allow (string-trim-right (sans-surrounding-whitespace
                                                  args) #\:))))
 
-(add-command! /allow "/allow" "/allow [USER@SERVER]" "Allow buddy to see your status")
+(add-command! /allow "allow" "/allow [USER@SERVER]" "Allow buddy to see your status")
 
 (define (/deny args)
   (if (= (string-length args) 0)
       (ft-display (_ "Incomplete syntax"))
       (ft-subscription-deny (string-trim-right (sans-surrounding-whitespace
                                                 args) #\:))))
-(add-command! /deny "/deny" "/deny [USER@SERVER]" "Deny buddy permission to see your status")
+(add-command! /deny "deny" "/deny [USER@SERVER]" "Deny buddy permission to see your status")
 
 (define (/alias args)
   (if (= (string-length args) 0)
       (ft-display (_ "Incomplete syntax"))
       (apply ft-roster-set-nickname (map sans-surrounding-whitespace
                                          (string-separate args #\space)))))
-(add-command! /alias "/alias" "/alias buddy nickname" "Set the nickname of a buddy")
+(add-command! /alias "alias" "/alias buddy nickname" "Set the nickname of a buddy")
 
 (define (subscribe-recv jid)
   (ft-display (string-append (_ "[Buddy request recieved from ") jid (_ " use /allow or /deny]")))

--- a/extensions/shell.scm
+++ b/extensions/shell.scm
@@ -19,7 +19,7 @@
 (define (/quit args)
   "exit freetalk"
   (ft-quit 0))
-(add-command! /quit "/quit" "quit" "quit this messenger")
+(add-command! /quit "quit" "quit" "quit this messenger")
 
 (define (/shell args)
   "dynamic command interface to shell facility"
@@ -30,14 +30,14 @@
         (system "sh"))
       (system args)))
 
-(add-command! /shell "/shell" "/shell [COMMAND] [ARGS]" "shell mode")
+(add-command! /shell "shell" "/shell [COMMAND] [ARGS]" "shell mode")
 
 (define (/restart args)
   "dynamic command interface to /restart facility"
   (ft-disconnect)
   (apply execlp "freetalk" "freetalk" '()))
 
-(add-command! /restart "/restart" "/restart" "restart freetalk")
+(add-command! /restart "restart" "/restart" "restart freetalk")
 
 (define (/date args)
   "dynamic command interface to /date facility"
@@ -45,7 +45,7 @@
       (system "date")
       (system (string-append "date " args))))
 
-(add-command! /date "/date" "/date [OPTIONS]" "print current date with all date OPTIONS")
+(add-command! /date "date" "/date [OPTIONS]" "print current date with all date OPTIONS")
 
 (add-hook! ft-quit-hook (lambda (dummy) (display
                                          (string-append "         ...   ...                            \n"

--- a/extensions/smart-prompt.scm
+++ b/extensions/smart-prompt.scm
@@ -110,7 +110,7 @@
                                     'pre "" 'post))))))
     (update-prompt)))
 
-(add-command! /next "/next" "/next" "display next message")
+(add-command! /next "next" "/next" "display next message")
 
 (define (/quiet-mode args)
   " quiet chat mode "
@@ -118,7 +118,7 @@
   (ft-display (_ " Quiet chat mode selected "))
   (update-prompt))
 
-(add-command! /quiet-mode "/quiet-mode" "quiet-mode" "Select quiet chat mode")
+(add-command! /quiet-mode "quiet-mode" "/quiet-mode" "Select quiet chat mode")
 
 (define (/normal-mode args)
   " normal chat mode "
@@ -126,7 +126,7 @@
   (ft-display (_ " Normal chat mode selected "))
   (update-prompt))
 
-(add-command! /normal-mode "/normal-mode" "normal-mode" "Select normal chat mode")
+(add-command! /normal-mode "normal-mode" "/normal-mode" "Select normal chat mode")
 
 
 (add-hook! ft-message-send-hook

--- a/extensions/state.scm
+++ b/extensions/state.scm
@@ -23,26 +23,26 @@
 
 (define (/prompt args)
   (usual-crap ft-get-prompt ft-set-prompt! "Current prompt: " args))
-(add-command! /prompt "/prompt" "/prompt [NEWPROMPT]" "set command line prompt")
+(add-command! /prompt "prompt" "/prompt [NEWPROMPT]" "set command line prompt")
 
 (define (/status args)
   (usual-crap ft-get-status-msg ft-set-status-msg! "Current status: " args))
-(add-command! /status "/status"
+(add-command! /status "status"
               "/status [online|away|chat|xa|dnd|invisible] [MESSAGE]"
               "set status message")
 
 (define (/server args)
   (usual-crap ft-get-server ft-set-server! "Current server: " args))
-(add-command! /server "/server" "/server [HOST|IP]"
+(add-command! /server "server" "/server [HOST|IP]"
               "set server for next /connect")
 
 (define (/jid args)
   (usual-crap ft-get-jid ft-set-jid! "Current JID: " args))
-(add-command! /jid "/jid" "/jid [USER@SERVER]" "set jabber id for next /connect")
+(add-command! /jid "jid" "/jid [USER@SERVER]" "set jabber id for next /connect")
 
 (define (/password args)
   (ft-set-password! (getpass "Password: ")))
-(add-command! /password "/password" "/password" "set password for next /connect")
+(add-command! /password "password" "/password" "set password for next /connect")
 
 (define (/port args)
   (usual-crap
@@ -50,13 +50,13 @@
    (lambda (str_port) (ft-set-port! (string->number str_port)))
    "Current Port (0 = default): "
    args))
-(add-command! /port "/port" "/port [PORT]" "set server port for next /connect")
+(add-command! /port "port" "/port [PORT]" "set server port for next /connect")
 
 (define (/proxyserver args)
   (usual-crap ft-get-proxyserver ft-set-proxyserver!
               "Current ProxyServer: "
               args))
-(add-command! /proxyserver "/proxyserver"
+(add-command! /proxyserver "proxyserver"
               "/proxyserver [HOST|IP]" "set proxy server for next /connect")
 
 (define (/proxyport args)
@@ -65,24 +65,24 @@
    (lambda (str_proxyport) (ft-set-proxyport! (string->number str_proxyport)))
    "Current Port (8080 = default): "
    args))
-(add-command! /proxyport "/proxyport" "/proxyport [PORT]"
+(add-command! /proxyport "proxyport" "/proxyport [PORT]"
               "set proxyserver port for next /connect")
 
 (define (/proxyuname args)
   (usual-crap ft-get-proxyuname ft-set-proxyuname! "Current ProxyUname: " args))
-(add-command! /proxyuname "/proxyuname" "/proxyuname [PROXYUSERNAME]"
+(add-command! /proxyuname "proxyuname" "/proxyuname [PROXYUSERNAME]"
               "set proxy username for next /connect")
 
 (define (/proxypasswd args)
   (ft-set-proxypasswd! (getpass "ProxyPassword: ")))
-(add-command! /proxypasswd "/proxypasswd" "/proxypasswd"
+(add-command! /proxypasswd "proxypasswd" "/proxypasswd"
               "set proxy password for next /connect")
 
 (add-command! (lambda (str)
                 (if (> (string-length str) 0)
                     (ft-load (sans-surrounding-whitespace str))
                     (ft-display (_ "usage: /load [FILE]"))))
-              "/load" "/load [FILE]" "load an extension file")
+              "load" "/load [FILE]" "load an extension file")
 
-(add-command! (lambda (args) (ft-reset-fs-state!)) "/setup"
+(add-command! (lambda (args) (ft-reset-fs-state!)) "setup"
               "/setup" "Write fresh ~/.freetalk")

--- a/extensions/url.scm
+++ b/extensions/url.scm
@@ -44,4 +44,4 @@
                              (string-trim-right (string-trim-right
                                                  args #\space) #\:)))))
 
-(add-command! /urlview "/urlview" "/urlview [BUDDY]" "handle URLs")
+(add-command! /urlview "urlview" "/urlview [BUDDY]" "handle URLs")

--- a/extensions/utils.scm
+++ b/extensions/utils.scm
@@ -27,12 +27,12 @@
                           (_ "This is free software; see the source for copying conditions.\n")
                           (_ "There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n"))))
 
-(add-command! /version "/version" "/version" "display freetalk version information")
+(add-command! /version "version" "/version" "display freetalk version information")
 
 (define (/run-cmd args)
   "run commands"
   (ft-run-command args))
-(add-command! /run-cmd "/run-cmd" "/run-cmd" "run command provided in args")
+(add-command! /run-cmd "run-cmd" "/run-cmd" "run command provided in args")
 
 ;; range with proper tail recursion --ab
 (define (range start end)


### PR DESCRIPTION
/help command should accept command without a lead slash :
- command names are stored in dynamic-command-registry without the lead slash
- interpreter.c is updated to know how to complete commands names preceded by a slash, or by /help command
