### PR TITLE
Use function of /bin/sh for autogen. This makes freetalk installation mo...

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 echo
 echo ... Freetalk autogen ...


### PR DESCRIPTION
...re friendly for the the not 'just Linux' world, for example: Solaris, HPUX and BSD OSes.

Tested on FreeBSD 10.0+
