### PR TITLE
freetalk: fix build on gcc-10 (-fno-common)

### DIFF
--- a/src/more.c
+++ b/src/more.c
@@ -34,6 +34,9 @@ gotsig (int sig)
   tcsetattr (fileno (cin), TCSANOW, &initial_settings);
 }
 
+struct termios initial_settings;
+FILE *cin;
+
 void
 more (char *buffer)
 {

--- a/src/more.h
+++ b/src/more.h
@@ -11,8 +11,8 @@
 #include <sys/stat.h>
 #include <string.h>
 
-struct termios initial_settings;
-FILE *cin;
+extern struct termios initial_settings;
+extern FILE *cin;
 
 void gotsig (int sig);
 void more (char *buffer);


### PR DESCRIPTION
gcc-10 changed the default from -fcommon to fno-common:
  https://gcc.gnu.org/PR85678

As a result build fails as:

    ld: more.o:src/./more.h:15: multiple definition of `cin'; primitives.o:src/./more.h:15: first defined here
    ld: more.o:src/./more.h:14: multiple definition of `initial_settings'; primitives.o:src/./more.h:14: first defined here

The change moves variable definitions to .c files.